### PR TITLE
Http/2 to origin fixes

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2262,6 +2262,10 @@ HttpSM::state_read_server_response_header(int event, void *data)
     if (allow_error == false) {
       SMDebug("http_seq", "Error parsing server response header");
       t_state.current.state = HttpTransact::PARSE_ERROR;
+      // set to 0, because else HttpTransact::retry_server_connection_not_open
+      // will assert on default value
+      // TODO: can we use a better value here?
+      t_state.cause_of_death_errno = 0;
 
       // If the server closed prematurely on us, use the
       //   server setup error routine since it will forward

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -151,7 +151,7 @@ rcv_data_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
     }
     if (!stream->payload_length_is_valid()) {
-      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "recv data bad payload length");
     }
 


### PR DESCRIPTION
Fixes for some crashers 
1. Error should be stream error according when a response is malformed https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.6 (content-length!=payload length)
2. Fix assertion crash on cause_of_death_errno in case of parse response (please check value)
3. Do not sent EOS or WRITE_COMPLETE to tunnel handlers which are not setup for them in outbound mode